### PR TITLE
Silence warnings

### DIFF
--- a/src/inifile.c
+++ b/src/inifile.c
@@ -33,7 +33,7 @@ static const char *_errors[] = { [NC_INI_ERROR_FILE] = "",
 
 const char *nc_ini_error(NcIniError error)
 {
-        int j = abs(error);
+        int j = abs((int)error);
         if (j < NC_INI_ERROR_FILE || j >= NC_INI_ERROR_MAX) {
                 return "[Unknown Error]";
         }


### PR DESCRIPTION
When using -Wabsolute-value the compiler will complain about using
absolute "enum <anonymous>", this patch makes the compiler happier.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>